### PR TITLE
Remove 'clear-x' when dropdown is disabled

### DIFF
--- a/src/mf-select.component.html
+++ b/src/mf-select.component.html
@@ -15,7 +15,7 @@
       ></ng-container>
     </div>
     <span class='mf-icons'>
-      <i class='mf-clear' *ngIf='selectedItem' (click)='selectItem(null); $event.stopPropagation()'></i>
+      <i class='mf-clear' *ngIf='selectedItem && !isDisabled' (click)='selectItem(null); $event.stopPropagation()'></i>
       <i class='mf-caret'></i>
     </span>
   </div>


### PR DESCRIPTION
As the title says, this is for hiding the clearing x button on the mf-select object when it is disabled. There can be situations where a selection is made and the component then disabled - as in the spraying-termination form recently. 

The idea is such a change such as this would remove some possible confusion for the user.
I'm not sure this implementation is ideal though, what would be your thoughts on the subject?